### PR TITLE
Removed .json URL requirement

### DIFF
--- a/transgator.js
+++ b/transgator.js
@@ -22,7 +22,7 @@ transgator.utils = {
 
 	getJSON : function(url, callback){
 		var req = new XMLHttpRequest();
-		req.open('GET', url + ".json");
+		req.open('GET', url);
 
 		req.onload = function() {
 			if(req.status == 200){


### PR DESCRIPTION
As per @toddmotto's feedback. This change allows transgator to be used with REST endpoints that can returnJSON translations
